### PR TITLE
dev-jonathan

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,6 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-EXPOSE 8080
-CMD [ "node", "server.js" ]
+EXPOSE 5000
+# CMD [ "node", "server.js" ]
+# CMD npm run start:dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - mongo
     links:
       - mongo
+    volumes:
+      - .:/app/src
+    command: npm run start:dev
   mongo:
     container_name: mongo
     image: mongo

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ const { typeDefs } = require("./schema/typedefs");
 const { resolvers } = require("./schema/resolvers");
 
 const app = express();
-
 const DB_HOST = "mongo:27017"; // localhost;
 
 mongoose.connect(`mongodb://${DB_HOST}/rageshipper`, {
@@ -22,4 +21,4 @@ server.applyMiddleware({ app });
 app.use(express.json());
 app.use("/create", (req, res, next) => next(), CREATE_ROUTER);
 
-app.listen(5000, () => console.log("Listening.."));
+app.listen(5000, () => console.log("Listening..."));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon server.js"
+    "start": "node index.js",
+    "start:dev": "nodemon -L index.js"
   },
   "keywords": [],
   "author": "",

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -67,7 +67,7 @@ const resolvers = {
   },
 
   Mutation: {
-    createPortfolio: async (_, args, { consultation }, info) => {
+    createConsultation: async (_, args, { consultation }, info) => {
       const newConsultation = new consultation({
         ...consultation,
       });

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -58,6 +58,14 @@ const resolvers = {
       return response;
     },
   },
+
+  RaidParty: {
+    raid(parent) {
+      //filter db to find and return RaidParty connected to the connected raid -- something like
+      return raidparties.filter((raidparty) => raidparty.raid === parent.raid);
+    },
+  },
+
   Mutation: {
     createPortfolio: async (_, args, { consultation }, info) => {
       const newConsultation = new consultation({

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -59,6 +59,14 @@ const resolvers = {
     },
   },
   Mutation: {
+    createPortfolio: async (_, args, { consultation }, info) => {
+      const newConsultation = new consultation({
+        ...consultation,
+      });
+      await consultation.create(newConsultation);
+      console.log(newConsultation);
+      return newConsultation;
+    },
     createRaid: async (_, args, context, info) => {
       const {
         raid_name,

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -33,10 +33,32 @@ const resolvers = {
         .populate("portfolio");
       return response;
     },
-
-    async raid(_parent, args, _context, _info) {
-      const { id } = args;
+    async raid(_parent, { id }, _context, _info) {
       const response = await raid.findById(id);
+      return response;
+    },
+    async member(_parent, { id }, _context, _info) {
+      const response = await member.findById(id);
+      return response;
+    },
+    async memberByEthAddress(_parent, { eth_address }, _context, _info) {
+      const response = await member.findOne({ eth_address: eth_address });
+      return response;
+    },
+    async consultation(_parent, { id }, _context, _info) {
+      const response = await consultation.findById(id);
+      return response;
+    },
+    async application(_parent, { id }, _context, _info) {
+      const response = await application.findById(id);
+      return response;
+    },
+    async portfolio(_parent, { id }, _context, _info) {
+      const response = await portfolio.findById(id);
+      return response;
+    },
+    async comment(_parent, { id }, _context, _info) {
+      const response = await comment.findById(id);
       return response;
     },
     async portfolios() {
@@ -59,6 +81,7 @@ const resolvers = {
     },
   },
 
+  // we can likely remove this as the other resolvers handle data collection relations
   RaidParty: {
     raid(parent) {
       //filter db to find and return RaidParty connected to the connected raid -- something like

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -10,6 +10,7 @@ const resolvers = {
   Query: {
     async consultations() {
       const response = await consultation.find().populate("raid");
+
       return response;
     },
     async applications() {

--- a/schema/typedefs.js
+++ b/schema/typedefs.js
@@ -125,6 +125,12 @@ const typeDefs = gql`
     raidparties: [RaidParty]
     comments: [Comment]
     raid(id: String): Raid
+    member(id: String): Member
+    memberByAddress(eth_address: String): Member
+    consultation(id: String): Consultation
+    application(id: String): Consultation
+    portfolio(id: String): Consultation
+    comment(id: String): Comment
   }
 
   ## inputs

--- a/schema/typedefs.js
+++ b/schema/typedefs.js
@@ -1,39 +1,6 @@
 const { gql } = require("apollo-server-express");
 
 const typeDefs = gql`
-  ## enums
-
-  enum PreferredContact {
-    Discord
-    Email
-    Telegram
-  }
-
-  # enum ProjectType {
-  #   New
-  #   Existing
-  # }
-
-  # enum AvailableProjectSpecs {
-  #   Yes
-  #   Partial
-  #   None
-  # }
-
-  # enum Budget {
-  #   < $5k
-  #    $5k - $20k
-  #   $20k - $50k
-  #   $50k +
-  #   Not Sure
-  # }
-
-  # enum DeliveryPriorities {
-  #   Fast & Polished
-  #   Fast & Inexpensive
-  #   Polished & Inexpensive
-  # }
-
   ## types
 
   type Consultation {

--- a/schema/typedefs.js
+++ b/schema/typedefs.js
@@ -1,6 +1,27 @@
 const { gql } = require("apollo-server-express");
 
 const typeDefs = gql`
+  ## enums
+
+  enum PreferredContact {
+    Discord
+    Email
+    Telegram
+  }
+
+  enum ProjectType {
+    New
+    Existing
+  }
+
+  enum AvailableProjectSpecs {
+    Yes
+    Partial
+    None
+  }
+
+  ## types
+
   type Consultation {
     id: ID!
     project_name: String!
@@ -128,7 +149,7 @@ const typeDefs = gql`
   ## inputs
 
   input RaidInput {
-    _id: String
+    _id: ID
     raid_name: String!
     status: String!
     category: String!
@@ -143,10 +164,37 @@ const typeDefs = gql`
     # # portfolio: Portfolio
   }
 
+  input ConsultationInput {
+    id: ID!
+    project_name: String!
+    contact_name: String!
+    contact_email: String!
+    contact_bio: String!
+    contact_discord: String
+    contact_telegram: String
+    preferred_contact: PreferredContact!
+    project_type: String!
+    project_specs: String!
+    specs_link: String
+    project_desc: String!
+    services_req: [String!]!
+    desired_delivery: String
+    budget: String!
+    delivery_priorities: String!
+    additional_info: String!
+    submission_type: String!
+    consultation_hash: String
+    submission_date: String!
+    feedback: String
+    rating: Int
+    raid: RaidInput
+  }
+
   ## mutations
 
   type Mutation {
     createRaid(raid: RaidInput): Raid
+    createConsultation(consultation: ConsultationInput): Consultation
     createPortfolio(
       _id: String!
       project_name: String

--- a/schema/typedefs.js
+++ b/schema/typedefs.js
@@ -3,22 +3,36 @@ const { gql } = require("apollo-server-express");
 const typeDefs = gql`
   ## enums
 
-  enum PreferredContact {
-    Discord
-    Email
-    Telegram
-  }
+  # enum PreferredContact {
+  #   Discord
+  #   Email
+  #   Telegram
+  # }
 
-  enum ProjectType {
-    New
-    Existing
-  }
+  # enum ProjectType {
+  #   New
+  #   Existing
+  # }
 
-  enum AvailableProjectSpecs {
-    Yes
-    Partial
-    None
-  }
+  # enum AvailableProjectSpecs {
+  #   Yes
+  #   Partial
+  #   None
+  # }
+
+  # enum Budget {
+  #   < $5k
+  #    $5k - $20k
+  #   $20k - $50k
+  #   $50k +
+  #   Not Sure
+  # }
+
+  # enum DeliveryPriorities {
+  #   Fast & Polished
+  #   Fast & Inexpensive
+  #   Polished & Inexpensive
+  # }
 
   ## types
 
@@ -165,14 +179,14 @@ const typeDefs = gql`
   }
 
   input ConsultationInput {
-    id: ID!
+    id: ID
     project_name: String!
     contact_name: String!
     contact_email: String!
     contact_bio: String!
     contact_discord: String
     contact_telegram: String
-    preferred_contact: PreferredContact!
+    preferred_contact: String!
     project_type: String!
     project_specs: String!
     specs_link: String

--- a/schema/typedefs.js
+++ b/schema/typedefs.js
@@ -136,13 +136,13 @@ const typeDefs = gql`
     category: String!
     cleric_name: String!
     roles_required: [String!]
-    # # raid_party: RaidParty
+    raid_party: RaidParty
     invoice_address: String
     start_date: String
     end_date: String
-    # # comments: [Comment!]
-    # # related_raids: [Raid!]
-    # # portfolio: Portfolio
+    comments: [Comment!]
+    related_raids: [Raid!]
+    portfolio: Portfolio
   }
 
   input ConsultationInput {

--- a/schema/typedefs.js
+++ b/schema/typedefs.js
@@ -3,11 +3,11 @@ const { gql } = require("apollo-server-express");
 const typeDefs = gql`
   ## enums
 
-  # enum PreferredContact {
-  #   Discord
-  #   Email
-  #   Telegram
-  # }
+  enum PreferredContact {
+    Discord
+    Email
+    Telegram
+  }
 
   # enum ProjectType {
   #   New

--- a/schema/typedefs.js
+++ b/schema/typedefs.js
@@ -129,6 +129,8 @@ const typeDefs = gql`
 
   ## inputs
 
+  # since we arent going to be using create mutations for right now we probably can remove these
+
   input RaidInput {
     _id: ID
     raid_name: String!
@@ -172,6 +174,8 @@ const typeDefs = gql`
   }
 
   ## mutations
+
+  # we can probably remove the create mutations since we're focusing on graphql for  mostly reads for now
 
   type Mutation {
     createRaid(raid: RaidInput): Raid

--- a/schema/typedefs.js
+++ b/schema/typedefs.js
@@ -136,6 +136,7 @@ const typeDefs = gql`
   ## inputs
 
   # since we arent going to be using create mutations for right now we probably can remove these
+  # ive commented out fields that would require creating additional inputs
 
   input RaidInput {
     _id: ID
@@ -144,13 +145,13 @@ const typeDefs = gql`
     category: String!
     cleric_name: String!
     roles_required: [String!]
-    raid_party: RaidParty
-    invoice_address: String
-    start_date: String
-    end_date: String
-    comments: [Comment!]
-    related_raids: [Raid!]
-    portfolio: Portfolio
+    # raid_party: RaidPartyInput
+    # invoice_address: String
+    # start_date: String
+    # end_date: String
+    # comments: [Comment!]
+    # related_raids: [Raid!]
+    # portfolio: PortfolioInput
   }
 
   input ConsultationInput {

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,90 +1,90 @@
 const SERVICES = [
-  'DAO (Design, Deployment)',
-  'Development (Frontend, Backend)',
-  'Marketing (Social Media, Copywriting, Memes/GIFs)',
-  'Motion Design (Video, Explainers, Sticker Packs)',
-  'NFTs (Contracts, Art, Tokenomics)',
-  'Smart Contracts (Solidity, Audits)',
-  'Strategy (Product, Launch Planning, Agile)',
-  'Tokenomics (Incentives, Distribution, Rewards)',
-  'UX (Research, Testing, User Stories)',
-  'UI (Interface Design, Interaction Design)',
-  'Visual Design (Branding, Illustration, Graphics)',
-  'Help me figure out what I need'
+  "DAO (Design, Deployment)",
+  "Development (Frontend, Backend)",
+  "Marketing (Social Media, Copywriting, Memes/GIFs)",
+  "Motion Design (Video, Explainers, Sticker Packs)",
+  "NFTs (Contracts, Art, Tokenomics)",
+  "Smart Contracts (Solidity, Audits)",
+  "Strategy (Product, Launch Planning, Agile)",
+  "Tokenomics (Incentives, Distribution, Rewards)",
+  "UX (Research, Testing, User Stories)",
+  "UI (Interface Design, Interaction Design)",
+  "Visual Design (Branding, Illustration, Graphics)",
+  "Help me figure out what I need",
 ];
 
-const PREFERRED_CONTACT = ['Discord', 'Email', 'Telegram'];
+const PREFERRED_CONTACT = ["Discord", "Email", "Telegram"];
 
-const PROJECT_TYPE = ['New', 'Existing'];
+const PROJECT_TYPE = ["New", "Existing"];
 
-const AVAILABLE_PROJECT_SPECS = ['Yes', 'Partial', 'None'];
+const AVAILABLE_PROJECT_SPECS = ["Yes", "Partial", "None"];
 
-const BUDGET = ['< $5k', '$5k - $20k', '$20k - $50k', '$50k +', 'Not Sure'];
+const BUDGET = ["< $5k", "$5k - $20k", "$20k - $50k", "$50k +", "Not Sure"];
 
 const DELIVERY_PRIORITIES = [
-  'Fast & Polished',
-  'Fast & Inexpensive',
-  'Polished & Inexpensive'
+  "Fast & Polished",
+  "Fast & Inexpensive",
+  "Polished & Inexpensive",
 ];
 
-const SUBMISSION_TYPE = ['Paid', 'Unpaid'];
+const SUBMISSION_TYPE = ["Paid", "Unpaid"];
 
 const SKILLS = [
-  'Frontend Dev',
-  'Backend Dev',
-  'Solidity',
-  'BizDev',
-  'Community',
-  'Project Management',
-  'Finance,',
-  'Product Design',
-  'UX Research',
-  'Game Theory',
-  'DevOps',
-  'Tokenomics',
-  'Content',
-  'Memes',
-  'Visual Design',
-  'UI Design',
-  'Illustration',
-  'Legal',
-  'Accounting'
+  "Frontend Dev",
+  "Backend Dev",
+  "Solidity",
+  "BizDev",
+  "Community",
+  "Project Management",
+  "Finance,",
+  "Product Design",
+  "UX Research",
+  "Game Theory",
+  "DevOps",
+  "Tokenomics",
+  "Content",
+  "Memes",
+  "Visual Design",
+  "UI Design",
+  "Illustration",
+  "Legal",
+  "Accounting",
 ];
 
-const SKILL_TYPE = ['Technical', 'Non - Technical', 'Other'];
+const SKILL_TYPE = ["Technical", "Non - Technical", "Other"];
 
-const DAO_FAMILIARITY = ['Expert', 'Familiar', 'A Little', 'None'];
+const DAO_FAMILIARITY = ["Expert", "Familiar", "A Little", "None"];
 
 const COHORT_AVAILABILITY = [
-  '0-5 hours',
-  '6-12 hours',
-  '13-35 hours',
-  '36+ hours'
+  "0-5 hours",
+  "6-12 hours",
+  "13-35 hours",
+  "36+ hours",
 ];
 
 const GUILD_CLASS = [
-  'Tavern Keeper (Community)',
-  'Archer (Design)',
-  'Angry Dwarf (Treasury)',
-  'Bard (Marketing)',
-  'Warrior (FrontEnd Dev)',
-  'Healer (Ops)',
-  'Hunter (BizDev)',
-  'Paladin (Backend Dev)',
-  'Monk (PM)',
-  'Wizard (Smart Contracts)',
-  'Rogue (Legal)'
+  "Tavern Keeper (Community)",
+  "Archer (Design)",
+  "Angry Dwarf (Treasury)",
+  "Bard (Marketing)",
+  "Warrior (FrontEnd Dev)",
+  "Healer (Ops)",
+  "Hunter (BizDev)",
+  "Paladin (Backend Dev)",
+  "Monk (PM)",
+  "Wizard (Smart Contracts)",
+  "Rogue (Legal)",
 ];
 
-const RAID_STATUS = ['Awaiting', 'Preparing', 'Raiding', 'Shipped', 'Lost'];
+const RAID_STATUS = ["Awaiting", "Preparing", "Raiding", "Shipped", "Lost"];
 
 const RAID_CATEGORY = [
-  'Design Sprint',
-  'Full Stack',
-  'Wizarding',
-  'Backend',
-  'Frontend',
-  'Marketing'
+  "Design Sprint",
+  "Full Stack",
+  "Wizarding",
+  "Backend",
+  "Frontend",
+  "Marketing",
 ];
 
 module.exports = {
@@ -101,5 +101,5 @@ module.exports = {
   COHORT_AVAILABILITY,
   GUILD_CLASS,
   RAID_STATUS,
-  RAID_CATEGORY
+  RAID_CATEGORY,
 };


### PR DESCRIPTION
This PR adds resolvers to `resolvers.js` for single response queries (by ID and eth_address).

I didn't have a chance to test these out since we need to add data via Postman, but they're showing up as valid in Graphiql. Happy to test these out with populated data, but they follow the same structure as the `raid(id...)` query I added which does work.

@manolingam -- for the `memberByAddress` query I used `.findOne` -- not sure if we should use `.find` or `.findOne` for this. The others use `.findById`

Also, I meant to bring this up on our call earlier but we may want to consider using the `ID` type instead of `String` in our GraphQL typedefs. These functionally work like strings so should be the same for our Mongo.

Thanks! 